### PR TITLE
Remove unnecessary timeout

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -9,9 +9,7 @@ module.exports = {
         
         eleventyConfig.addNunjucksAsyncFilter("duration", async function(filePath, callback) {
             let duration = await getDuration(filePath);
-            setTimeout(function() {           
-                callback(null, duration);
-            }, 100);
+            callback(null, duration);
         });
         
         


### PR DESCRIPTION
It seems like the following code [in the docs](https://www.11ty.dev/docs/languages/nunjucks/) is used to show how Nunjucks could work asynchronously:

```js
module.exports = function(eleventyConfig) {
  eleventyConfig.addNunjucksAsyncFilter("myAsyncFilter", function(value1, value2, callback) {
    setTimeout(function() {
      callback(null, "My Result");
    }, 100);
  });
};
```

Meaning that you don’t need it while using `addNunjucksAsyncFilter`.

In my case I went from 24s to 1s after removing this `setTimeout` wrapper.